### PR TITLE
Use only a single, static instance of System.Random to generate payloads

### DIFF
--- a/src/Ksuid/Ksuid.cs
+++ b/src/Ksuid/Ksuid.cs
@@ -11,14 +11,17 @@ namespace KSUID
         private const int TimestampSize = 4;
         private const uint Epoch = 1400000000;
         private static readonly DateTime EpochDateTime = new DateTime(2014, 05, 13, 16, 53, 20, DateTimeKind.Utc);
+        private static readonly Random RandomGen = new Random();
         private readonly byte[] _payload;
         private readonly uint _timestamp;
 
         public Ksuid()
         {
             var byteArray = new byte[PayloadSize];
-            var random = new Random();
-            random.NextBytes(byteArray);
+            lock (RandomGen)
+            { 
+                RandomGen.NextBytes(byteArray);
+            }
             _payload = byteArray;
 
             _timestamp = Convert.ToUInt32(DateTimeOffset.UtcNow.ToUnixTimeSeconds() - Epoch);

--- a/tests/KsuidTests/KsuidTests.cs
+++ b/tests/KsuidTests/KsuidTests.cs
@@ -60,5 +60,17 @@ namespace KsuidTests
             Assert.Equal((uint)1494985761, ksuid.GetUnixTimestamp());
             Assert.Equal("D7B6FE8CD7CFF211704D8E7B9421210B", BitConverter.ToString(ksuid.GetPayload()).Replace("-",""));
         }
+
+        [Fact]
+        public void TestShouldGenerateDifferentPayload()
+        {
+            var ksuid1 = new Ksuid();
+            var ksuid2 = new Ksuid();
+            
+            // this is due to the .NET Framework Random implementation,
+            // which takes the seed as time-based and will produce same values
+            // when two instances of System.Random are created within a short duration
+            Assert.NotEqual(ksuid1.GetPayload(), ksuid2.GetPayload());
+        }
     }
 }


### PR DESCRIPTION
Hi, I was able to spot something for improvement.

This is due too two reasons:
* System.Random implementation in .NET Framework (see [System.Random on MSDN](https://docs.microsoft.com/en-us/dotnet/api/system.random?view=net-6.0#instantiating-the-random-number-generator)) and the added Test-Case
* Performance

I've done a quick performance comparison using BenchmarkDotNet. With this small change, I was able to lower the **allocated memory by ~80%** and the **generation time by ~85%** for every single KSUID generated. This is due to the costly allocation of a new `Random` instance. The full result is printed below.

```bash
// * Summary *

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1586 (21H1/May2021Update)
Intel Core i7-7500U CPU 2.70GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET SDK=5.0.101
  [Host]     : .NET 5.0.1 (5.0.120.57516), X64 RyuJIT
  DefaultJob : .NET 5.0.1 (5.0.120.57516), X64 RyuJIT


|               Method |   N |         Mean |       Error |       StdDev |   Gen 0 | Allocated |
|--------------------- |---- |-------------:|------------:|-------------:|--------:|----------:|
|          CreateKsuid |   1 |   2,455.5 ns |    77.61 ns |    228.83 ns |  0.1678 |     352 B |
| CreateKsuidOptimized |   1 |     319.6 ns |     9.55 ns |     28.02 ns |  0.0343 |      72 B |
|          CreateKsuid |  10 |  25,078.5 ns |   709.29 ns |  2,091.34 ns |  1.6785 |   3,520 B |
| CreateKsuidOptimized |  10 |   3,283.2 ns |   104.70 ns |    305.41 ns |  0.3433 |     720 B |
|          CreateKsuid | 100 | 250,311.3 ns | 6,117.99 ns | 17,942.99 ns | 16.6016 |  35,200 B |
| CreateKsuidOptimized | 100 |  31,483.5 ns |   810.98 ns |  2,326.84 ns |  3.4180 |   7,200 B |

// * Warnings *
MultimodalDistribution
  KsuidBenchmark.CreateKsuidOptimized: Default -> It seems that the distribution is bimodal (mValue = 3.29)

// * Hints *
Outliers
  KsuidBenchmark.CreateKsuidOptimized: Default -> 1 outlier  was  removed (429.49 ns)
  KsuidBenchmark.CreateKsuidOptimized: Default -> 2 outliers were removed (4.38 us, 4.97 us)
  KsuidBenchmark.CreateKsuid: Default          -> 1 outlier  was  removed (301.74 us)
  KsuidBenchmark.CreateKsuidOptimized: Default -> 5 outliers were removed (38.53 us..42.95 us)

// * Legends *
  N         : Value of the 'N' parameter
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Gen 0     : GC Generation 0 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)

```